### PR TITLE
Add `block_on`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -411,3 +411,11 @@ impl Future for YieldNow {
         }
     }
 }
+
+/// Runs a future to completion on the current thread.
+///
+/// This function will block the caller until the given future has completed.
+pub fn block_on<F: Future>(f: F) -> <F as Future>::Output {
+    let f = core::pin::pin!(f);
+    Cassette::new(f).block_on()
+}


### PR DESCRIPTION
## Motivation

Provide a no-std version of [`futures::executor::block_on`](https://docs.rs/futures/latest/futures/executor/fn.block_on.html).

This is a use-case that has come up repeatedly in the `rtic`/`embedded-hal` chat rooms. They ask what a `no-std` alternative to `futures::executor::block_on` is, and I'd like to point them to this crate.

This change introduces a high-level function that has the same API as the version of `futures::executor`, for convenience.